### PR TITLE
I think this was an typo in the previous commit, leading to this error up

### DIFF
--- a/src/django_fields/fields.py
+++ b/src/django_fields/fields.py
@@ -150,7 +150,7 @@ class BaseEncryptedDateField(BaseEncryptedField):
             date_text = value.strftime(self.save_format)
         else:
             date_text = None
-        return super(BaseEncryptedDateField, self).get_db_prep_value(date_text, connection=None, prepared)
+        return super(BaseEncryptedDateField, self).get_db_prep_value(date_text, connection, prepared)
 
 
 class EncryptedDateField(BaseEncryptedDateField):


### PR DESCRIPTION
I think this was an typo in the previous commit, leading to this error upon installation:

$ pip install git+git://github.com/svetlyak40wt/django-fields.git#egg=django-fields
Downloading/unpacking git+git://github.com/svetlyak40wt/django-fields.git#egg=django-fields
  Cloning Git repository git://github.com/svetlyak40wt/django-fields.git to /tmp/pip-caoimu-build
  Running setup.py egg_info for package from git+git://github.com/svetlyak40wt/django-fields.git#egg=django-fields
Requirement already satisfied (use --upgrade to upgrade): pycrypto in ./env_localdev/lib/python2.6/site-packages (from django-fields)
Installing collected packages: django-fields
  Running setup.py install for django-fields
    SyntaxError: ('non-keyword arg after keyword arg', ('/home/ci/env_localdev/lib/python2.6/site-packages/django_fields/fields.py', 153, None, 'return super(BaseEncryptedDateField, self).get_db_prep_value(date_text, connection=None, prepared)\n'))

Successfully installed django-fields
