### PR TITLE
Do not encrypt None values

### DIFF
--- a/src/django_fields/fields.py
+++ b/src/django_fields/fields.py
@@ -65,9 +65,12 @@ class BaseEncryptedField(models.Field):
         return value
 
     def get_db_prep_value(self, value, connection=None, prepared=False):
+        if value is None:
+            return None
+
         value = smart_str(value)
 
-        if value is not None and not self._is_encrypted(value):
+        if not self._is_encrypted(value):
             padding  = self._get_padding(value)
             if padding > 0:
                 value += "\0" + ''.join([random.choice(string.printable)

--- a/src/django_fields/tests.py
+++ b/src/django_fields/tests.py
@@ -21,7 +21,7 @@ from .models import ModelWithPrivateFields
 
 class EncObject(models.Model):
     max_password = 20
-    password = EncryptedCharField(max_length=max_password)
+    password = EncryptedCharField(max_length=max_password, null=True)
 
 
 class EncDate(models.Model):
@@ -118,6 +118,17 @@ class EncryptTests(unittest.TestCase):
         for pwd_length in range(1,21):  # 1-20 inclusive
             password = 'a' * pwd_length  # 'a', 'aa', ...
             self.assertTrue(enc_field._get_padding(password) >= 2)
+
+    def test_none_value(self):
+        """
+        A value of None should be passed through without encryption.
+        """
+        obj = EncObject(password=None)
+        obj.save()
+        obj = EncObject.objects.get(id=obj.id)
+        self.assertEqual(obj.password, None)
+        encrypted_text = self._get_encrypted_password(obj.id)
+        self.assertEqual(encrypted_text, None)
 
     ### Utility methods for tests ###
 


### PR DESCRIPTION
Currently, a value of None will be interpreted as the string 'None' and stored encrypted in the database. This means that when you read it back, you get the string 'None' instead of an actual None.

This pull request fixes that by skipping encryption for None values.
