### PR TITLE
Change import pickle behavior

### DIFF
--- a/src/django_fields/fields.py
+++ b/src/django_fields/fields.py
@@ -12,13 +12,9 @@ from django.conf import settings
 from django.utils.encoding import smart_str, force_unicode
 from django.utils.translation import ugettext_lazy as _
 
-
-try:
-    USE_CPICKLE = settings.USE_CPICKLE
+if hasattr(settings, 'USE_CPICKLE'):
     warnings.warn("The USE_CPICKLE options is now obsolete. cPickle will always
     be used unless it cannot be found or DEBUG=True",DeprecationWarning))
-except AttributeError:
-    pass
 
 if settings.DEBUG:
     import pickle


### PR DESCRIPTION
I understand that one might want to use Pickle instead of cPickle. However, seeing the code there's no reason to use Pickle in a production environment over cPickle which is quite a few times faster (unless I'm missing something).

Because of this I propose this patch, to load pickle only when we're debugging or if importing cPickle fails.
