### PR TITLE
The warning message string was throwing a syntax error as was on one line

### DIFF
--- a/src/django_fields/fields.py
+++ b/src/django_fields/fields.py
@@ -14,7 +14,7 @@ from django.utils.translation import ugettext_lazy as _
 
 if hasattr(settings, 'USE_CPICKLE'):
     warnings.warn("The USE_CPICKLE options is now obsolete. cPickle will always "
-    "be used unless it cannot be found or DEBUG=True",DeprecationWarning))
+    "be used unless it cannot be found or DEBUG=True",DeprecationWarning)
 
 if settings.DEBUG:
     import pickle


### PR DESCRIPTION
I've modified the django_fields/fields.py file (line 16) as it was throwing an error about the ending quote for the string.  

  File "/home/jjasinski/Sites/flowershop/lib/python2.6/site-packages/django/utils/importlib.py", line 35, in import_module
    **import**(name)
  File "/home/jjasinski/Sites/flowershop/flowershop-trunk/flowershop/models.py", line 7, in <module>
    from django_fields import fields as enc_fields
  File "/home/jjasinski/Sites/flowershop/src/django-fields/src/django_fields/fields.py", line 16
    warnings.warn("The USE_CPICKLE options is now obsolete. cPickle will always
