### PR TITLE
Fixed CharField widget max_length validation

### DIFF
--- a/src/django_fields/fields.py
+++ b/src/django_fields/fields.py
@@ -99,7 +99,7 @@ class EncryptedCharField(BaseEncryptedField):
         return "CharField"
 
     def formfield(self, **kwargs):
-        defaults = {'max_length': self.max_length}
+        defaults = {'max_length': self.unencrypted_length}
         defaults.update(kwargs)
         return super(EncryptedCharField, self).formfield(**defaults)
 


### PR DESCRIPTION
``` console
diff --git a/src/django_fields/fields.py b/src/django_fields/fields.py
index 9f94b2c..c7c97b9 100644
--- a/src/django_fields/fields.py
+++ b/src/django_fields/fields.py
@@ -99,7 +99,7 @@ class EncryptedCharField(BaseEncryptedField):
         return "CharField"

     def formfield(self, **kwargs):
-        defaults = {'max_length': self.unencrypted_length}
+        defaults = {'max_length': self.max_length}
         defaults.update(kwargs)
         return super(EncryptedCharField, self).formfield(**defaults)
```
