### PR TITLE
Introspection rules to fix issue #10

### DIFF
--- a/src/django_fields/fields.py
+++ b/src/django_fields/fields.py
@@ -291,13 +291,25 @@ try:
     add_introspection_rules([
         (
             [
-                BaseEncryptedField, EncryptedDateField, BaseEncryptedDateField, EncryptedCharField, EncryptedTextField,
-                EncryptedFloatField, EncryptedDateTimeField, BaseEncryptedNumberField, EncryptedIntField, EncryptedLongField,
-                EncryptedUSPhoneNumberField, EncryptedEmailField,
+                BaseEncryptedField, EncryptedDateField, BaseEncryptedDateField,
+                EncryptedTextField, EncryptedFloatField,
+                EncryptedDateTimeField, BaseEncryptedNumberField,
+                EncryptedIntField, EncryptedLongField,
             ],
             [],
             {
                 'cipher':('cipher_type', {}),
+            },
+        ),
+        (
+            [
+                EncryptedCharField, EncryptedUSPhoneNumberField,
+                EncryptedEmailField,
+            ],
+            [],
+            {
+                'cipher':('cipher_type', {}),
+                "max_length": ["unencrypted_length", {"default": None}],
             },
         ),
     ], ["^django_fields\.fields\..+?Field"])


### PR DESCRIPTION
When south introspects classes for encrypted char fields it should use unencrypted_length attribute as max_length keyword argument because original max_length argument is overwriten by max_length for encrypted value. See https://github.com/svetlyak40wt/django-fields/issues/10
