### PR TITLE
fix: null number field

### DIFF
--- a/src/django_fields/fields.py
+++ b/src/django_fields/fields.py
@@ -76,8 +76,7 @@ class BaseEncryptedField(models.Field):
         if value is not None and not self._is_encrypted(value):
             padding  = self._get_padding(value)
             if padding > 0:
-                #value += "\0" + ''.join([random.choice(string.printable)
-                value += "\0" + ''.join(['\1'
+                value += "\0" + ''.join([random.choice(string.printable)
                     for index in range(padding-1)])
             value = self.prefix + binascii.b2a_hex(self.cipher.encrypt(value))
         return value


### PR DESCRIPTION
Currently, if number field is None, an exception will be raised.
So there's no way to make the number field nullable.
