### PR TITLE
Add block_type to south introspection rules

### DIFF
--- a/src/django_fields/fields.py
+++ b/src/django_fields/fields.py
@@ -301,10 +301,10 @@ class EncryptedUSPhoneNumberField(BaseEncryptedField):
 
 class EncryptedUSSocialSecurityNumberField(BaseEncryptedField):
     __metaclass__ = models.SubfieldBase
-    
+
     def get_internal_type(self):
         return "CharField"
-    
+
     def formfield(self, **kwargs):
         from django.contrib.localflavor.us.forms import USSocialSecurityNumberField
         defaults = {'form_class': USSocialSecurityNumberField}
@@ -336,12 +336,8 @@ try:
             ],
             [],
             {
-<<<<<<< HEAD
-                'cipher':('cipher_type', {}),
-=======
                 'cipher': ('cipher_type', {}),
                 'block_type': ('block_type', {}),
->>>>>>> f5ec63e... add block_type to the south introspection rules
             },
         ),
     ], ["^django_fields\.fields\..+?Field"])


### PR DESCRIPTION
It seems block_type wasn't added to the south rules. This patch adds it.
