### PR TITLE
Fix column width (max_length) issue when using block_type

### DIFF
--- a/src/django_fields/fields.py
+++ b/src/django_fields/fields.py
@@ -69,6 +69,8 @@ class BaseEncryptedField(models.Field):
         mod = max_length % self.cipher.block_size
         if mod > 0:
             max_length += self.cipher.block_size - mod
+        if self.block_type:
+            max_length += len(self.iv)
         kwargs['max_length'] = max_length * 2 + len(self.prefix)
 
         super(BaseEncryptedField, self).__init__(*args, **kwargs)


### PR DESCRIPTION
A deprecation warning in `fields.py` suggests use of `block_type='MODE_CBC'`. However, upon doing so, code as simple as the following fails when backed by PostgreSQL:

```python
class Thing(models.Model):
    important_date = fields.EncryptedDateField(block_type='MODE_CBC')

my_thing = Thing(important_date=timezone.now().date())
my_thing.save()
```
The error looks like this:
```python
DataError: value too long for type character varying(46)
```
The root cause is that we're trying to pack an encrypted value of _78 characters_ into a field which we told the database when introspecting/migrating would be at most 46 characters wide. This is because when `block_type` is not `None`, an initialization vector (`self.iv`) is added to the encrypted value (see `fields.py:BaseEncryptedField.get_db_prep_value`). This does not happen when no `block_type` is specified.

Impact is not limited to `EncryptedDateField`, by the way. It applies to everything derived from `BaseEncryptedField`. But the date field is the most obvious example because the `max_length` is always exactly the width needed to store a `Date`.

Further complicating things, _SQLite doesn't actually seem to care_ when columns exceed the maximum width you told it they would have on table creation. But serious databases like MySQL and Postgres do.

In order to demonstrate the issue in a failing test, because tests are also run with SQLite, I had to use database schema introspection to compare the schema-expected value and the size of the real saved value. This is the first commit.

The second commit fixes the issue. The third one adds one more test just for fun.